### PR TITLE
Add ManifestoBlock component with column layout support

### DIFF
--- a/src/blocks/Content/config.ts
+++ b/src/blocks/Content/config.ts
@@ -1,67 +1,9 @@
-import type { Block, Field } from 'payload'
+import type { Block } from 'payload'
 
-import {
-  FixedToolbarFeature,
-  HeadingFeature,
-  InlineToolbarFeature,
-  lexicalEditor,
-} from '@payloadcms/richtext-lexical'
 
-import { link } from '@/fields/link'
+import { columnFields } from '@/fields/column'
 
-const columnFields: Field[] = [
-  {
-    name: 'size',
-    type: 'select',
-    defaultValue: 'oneThird',
-    options: [
-      {
-        label: 'One Third',
-        value: 'oneThird',
-      },
-      {
-        label: 'Half',
-        value: 'half',
-      },
-      {
-        label: 'Two Thirds',
-        value: 'twoThirds',
-      },
-      {
-        label: 'Full',
-        value: 'full',
-      },
-    ],
-  },
-  {
-    name: 'richText',
-    type: 'richText',
-    editor: lexicalEditor({
-      features: ({ rootFeatures }) => {
-        return [
-          ...rootFeatures,
-          HeadingFeature({ enabledHeadingSizes: ['h2', 'h3', 'h4'] }),
-          FixedToolbarFeature(),
-          InlineToolbarFeature(),
-        ]
-      },
-    }),
-    label: false,
-  },
-  {
-    name: 'enableLink',
-    type: 'checkbox',
-  },
-  link({
-    overrides: {
-      admin: {
-        condition: (_data, siblingData) => {
-          return Boolean(siblingData?.enableLink)
-        },
-      },
-    },
-  }),
-]
+
 
 export const Content: Block = {
   slug: 'content',

--- a/src/blocks/ManifestoBlock/Component.tsx
+++ b/src/blocks/ManifestoBlock/Component.tsx
@@ -1,0 +1,59 @@
+import type React from "react"
+import { cn } from '@/utilities/ui'
+import RichText from '@/components/RichText'
+import type { ManifestoBlock as ManifestoBlockProps } from '@/payload-types'
+import { CMSLink } from '../../components/Link'
+
+export const ManifestoBlock: React.FC<ManifestoBlockProps> = (props) => {
+  const {
+    smallHeading,
+    largeHeading,
+    columns,
+  } = props
+
+  const colsSpanClasses = {
+    full: '12',
+    half: '6',
+    oneThird: '4',
+    twoThirds: '8',
+  }
+
+  return (
+    <div className="flex min-h-screen">
+      <main className="flex-1 md:ml-56 flex flex-col px-6 md:px-12 lg:px-16 py-16 md:py-24">
+        <span className="font-mono text-sm uppercase tracking-[0.3em] text-muted-foreground mb-4 text-center md:text-left">
+          {smallHeading}
+        </span>
+
+        <h2 className="text-2xl md:text-4xl lg:text-5xl font-bold text-primary mb-8 text-balance text-center md:text-left">
+          {largeHeading}
+        </h2>
+
+        <div className="grid grid-cols-4 lg:grid-cols-12 gap-y-8 gap-x-16 max-w-3xl">
+          {columns &&
+            columns.length > 0 &&
+            columns.map((col, index) => {
+              const { enableLink, link, richText, size } = col
+
+              return (
+                <div
+                  className={cn(`col-span-4 lg:col-span-${colsSpanClasses[size!]}`, {
+                    'md:col-span-2': size !== 'full',
+                  })}
+                  key={index}
+                >
+                  {richText && <RichText data={richText} enableGutter={false} />}
+
+                  {enableLink && <CMSLink {...link} className="self-center md:self-start relative border border-primary bg-transparent
+                    px-10 py-4 font-mono text-sm uppercase tracking-widest text-primary transition-colors hover:bg-primary
+                    hover:text-primary-foreground">
+                    <span className="absolute inset-0 animate-pulse border border-primary opacity-50" />
+                  </CMSLink>}
+                </div>
+              )
+            })}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/blocks/ManifestoBlock/config.ts
+++ b/src/blocks/ManifestoBlock/config.ts
@@ -1,0 +1,31 @@
+import type { Block } from 'payload'
+import { columnFields } from '@/fields/column'
+
+export const ManifestoBlock: Block = {
+  slug: 'manifestoBlock',
+  labels: {
+    singular: 'Manifesto',
+    plural: 'Manifestos',
+  },
+  interfaceName: 'ManifestoBlock',
+  fields: [
+    {
+      name: 'smallHeading',
+      label: 'Small Heading',
+      type: 'text',
+    },
+    {
+      name: 'largeHeading',
+      label: 'Large Heading',
+      type: 'text',
+    },
+    {
+      name: 'columns',
+      type: 'array',
+      admin: {
+        initCollapsed: true,
+      },
+      fields: columnFields,
+    }
+  ],
+}

--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -8,6 +8,7 @@ import { ContentBlock } from '@/blocks/Content/Component'
 import { FormBlock } from '@/blocks/Form/Component'
 import { MediaBlock } from '@/blocks/MediaBlock/Component'
 import { SplashScreenBlock } from './SplashScreen/Component'
+import { ManifestoBlock } from './ManifestoBlock/Component'
 
 
 const blockComponents = {
@@ -17,6 +18,7 @@ const blockComponents = {
   formBlock: FormBlock,
   mediaBlock: MediaBlock,
   splashScreenBlock: SplashScreenBlock,
+  manifestoBlock: ManifestoBlock
 }
 
 export const RenderBlocks: React.FC<{

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -21,6 +21,7 @@ import {
   PreviewField,
 } from '@payloadcms/plugin-seo/fields'
 import { SplashScreen } from '@/blocks/SplashScreen/config'
+import { ManifestoBlock } from '@/blocks/ManifestoBlock/config'
 
 export const Pages: CollectionConfig<'pages'> = {
   slug: 'pages',
@@ -73,7 +74,7 @@ export const Pages: CollectionConfig<'pages'> = {
             {
               name: 'layout',
               type: 'blocks',
-              blocks: [CallToAction, Content, MediaBlock, Archive, FormBlock, SplashScreen],
+              blocks: [CallToAction, Content, MediaBlock, Archive, FormBlock, SplashScreen, ManifestoBlock],
               required: false,
               admin: {
                 initCollapsed: true,

--- a/src/fields/column.ts
+++ b/src/fields/column.ts
@@ -1,0 +1,64 @@
+import type { Field } from 'payload'
+
+import {
+  FixedToolbarFeature,
+  HeadingFeature,
+  InlineToolbarFeature,
+  lexicalEditor,
+} from '@payloadcms/richtext-lexical'
+
+import { link } from '@/fields/link'
+
+export const columnFields: Field[] = [
+  {
+    name: 'size',
+    type: 'select',
+    defaultValue: 'oneThird',
+    options: [
+      {
+        label: 'One Third',
+        value: 'oneThird',
+      },
+      {
+        label: 'Half',
+        value: 'half',
+      },
+      {
+        label: 'Two Thirds',
+        value: 'twoThirds',
+      },
+      {
+        label: 'Full',
+        value: 'full',
+      },
+    ],
+  },
+  {
+    name: 'richText',
+    type: 'richText',
+    editor: lexicalEditor({
+      features: ({ rootFeatures }) => {
+        return [
+          ...rootFeatures,
+          HeadingFeature({ enabledHeadingSizes: ['h2', 'h3', 'h4'] }),
+          FixedToolbarFeature(),
+          InlineToolbarFeature(),
+        ]
+      },
+    }),
+    label: false,
+  },
+  {
+    name: 'enableLink',
+    type: 'checkbox',
+  },
+  link({
+    overrides: {
+      admin: {
+        condition: (_data, siblingData) => {
+          return Boolean(siblingData?.enableLink)
+        },
+      },
+    },
+  }),
+]

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -200,7 +200,9 @@ export interface Page {
       | null;
     media?: (number | null) | Media;
   };
-  layout?: (CallToActionBlock | ContentBlock | MediaBlock | ArchiveBlock | FormBlock | SplashScreenBlock)[] | null;
+  layout?:
+    | (CallToActionBlock | ContentBlock | MediaBlock | ArchiveBlock | FormBlock | SplashScreenBlock | ManifestoBlock)[]
+    | null;
   meta?: {
     title?: string | null;
     /**
@@ -811,6 +813,58 @@ export interface SplashScreenBlock {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ManifestoBlock".
+ */
+export interface ManifestoBlock {
+  smallHeading?: string | null;
+  largeHeading?: string | null;
+  columns?:
+    | {
+        size?: ('oneThird' | 'half' | 'twoThirds' | 'full') | null;
+        richText?: {
+          root: {
+            type: string;
+            children: {
+              type: any;
+              version: number;
+              [k: string]: unknown;
+            }[];
+            direction: ('ltr' | 'rtl') | null;
+            format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+            indent: number;
+            version: number;
+          };
+          [k: string]: unknown;
+        } | null;
+        enableLink?: boolean | null;
+        link?: {
+          type?: ('reference' | 'custom') | null;
+          newTab?: boolean | null;
+          reference?:
+            | ({
+                relationTo: 'pages';
+                value: number | Page;
+              } | null)
+            | ({
+                relationTo: 'posts';
+                value: number | Post;
+              } | null);
+          url?: string | null;
+          label: string;
+          /**
+           * Choose how the link should be rendered.
+           */
+          appearance?: ('default' | 'outline' | 'link') | null;
+        };
+        id?: string | null;
+      }[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'manifestoBlock';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "redirects".
  */
 export interface Redirect {
@@ -1118,6 +1172,7 @@ export interface PagesSelect<T extends boolean = true> {
         archive?: T | ArchiveBlockSelect<T>;
         formBlock?: T | FormBlockSelect<T>;
         splashScreenBlock?: T | SplashScreenBlockSelect<T>;
+        manifestoBlock?: T | ManifestoBlockSelect<T>;
       };
   meta?:
     | T
@@ -1233,6 +1288,34 @@ export interface SplashScreenBlockSelect<T extends boolean = true> {
         url?: T;
         label?: T;
         appearance?: T;
+      };
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "ManifestoBlock_select".
+ */
+export interface ManifestoBlockSelect<T extends boolean = true> {
+  smallHeading?: T;
+  largeHeading?: T;
+  columns?:
+    | T
+    | {
+        size?: T;
+        richText?: T;
+        enableLink?: T;
+        link?:
+          | T
+          | {
+              type?: T;
+              newTab?: T;
+              reference?: T;
+              url?: T;
+              label?: T;
+              appearance?: T;
+            };
+        id?: T;
       };
   id?: T;
   blockName?: T;


### PR DESCRIPTION
- Create new ManifestoBlock component with small/large heading fields
- Extract column fields to reusable column.ts module
- Update Content block to use shared column fields
- Add ManifestoBlock to page layout blocks
- Update payload types to include new block interface
- Support customizable column layouts with rich text and links